### PR TITLE
Fix Sublime Text 3 compatibility

### DIFF
--- a/mari_sublime.py
+++ b/mari_sublime.py
@@ -41,6 +41,6 @@ class MariCommand(sublime_plugin.TextCommand):
 		
 		cmd = str('\n'.join(snips))
 		
-		connection.write(cmd)
-		connection.write("\x04")
+		connection.write(cmd.encode(encoding='UTF-8'))
+		connection.write("\x04".encode(encoding='UTF-8'))
 		connection.close()


### PR DESCRIPTION
Sublime Text 3 use Python 3, and here are the changes related to the problem:
https://docs.python.org/release/3.0.1/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit
